### PR TITLE
test 4.04 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ env:
         - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
         - TESTS=false
     matrix:
-        - OCAML_VERSION=4.03
         - OCAML_VERSION=4.02
+        - OCAML_VERSION=4.03
+        - OCAML_VERSION=4.04


### PR DESCRIPTION
retaining the 4.02 build since it does not hurt, and travis reports error quickly with 4.02 being preinstalled