### PR TITLE
Correctly use Cstruct buffer offset

### DIFF
--- a/opam
+++ b/opam
@@ -24,7 +24,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-net-lwt" {>= "1.0.0"}
   "ipaddr" {>= "1.0.0"}
-  "mirage-solo5" {>= "0.3.0" & < "0.5.0"}
+  "mirage-solo5" {>= "0.5.0" & < "0.6.0"}
   "logs" {>= "0.6.0"}
   "fmt"
 ]

--- a/src/netif.ml
+++ b/src/netif.ml
@@ -53,9 +53,9 @@ type solo5_net_info = {
 external solo5_net_info:
   unit -> solo5_net_info = "mirage_solo5_net_info"
 external solo5_net_read:
-  Cstruct.buffer -> int -> solo5_result * int = "mirage_solo5_net_read"
+  Cstruct.buffer -> int -> int -> solo5_result * int = "mirage_solo5_net_read_2"
 external solo5_net_write:
-  Cstruct.buffer -> int -> solo5_result = "mirage_solo5_net_write"
+  Cstruct.buffer -> int -> int -> solo5_result = "mirage_solo5_net_write_2"
 
 let devices = Hashtbl.create 1
 
@@ -87,7 +87,8 @@ type buffer = Cstruct.t
 (* Input a frame, and block if nothing is available *)
 let rec read t buf =
   let process () =
-    let r = match solo5_net_read buf.Cstruct.buffer buf.Cstruct.len with
+    let r = match solo5_net_read
+        buf.Cstruct.buffer buf.Cstruct.off buf.Cstruct.len with
       | (SOLO5_R_OK, len)    ->
         t.stats.rx_pkts <- Int32.succ t.stats.rx_pkts;
         t.stats.rx_bytes <- Int64.add t.stats.rx_bytes (Int64.of_int len);
@@ -139,7 +140,7 @@ let rec listen t fn =
 (* Transmit a packet from a Cstruct.t *)
 let write t buf =
   let open Cstruct in
-  let r = match solo5_net_write buf.buffer buf.len with
+  let r = match solo5_net_write buf.buffer buf.off buf.len with
     | SOLO5_R_OK      ->
       t.stats.tx_pkts <- Int32.succ t.stats.tx_pkts;
       t.stats.tx_bytes <- Int64.add t.stats.tx_bytes (Int64.of_int buf.len);


### PR DESCRIPTION
Top half of mirage/mirage-solo5#37

Cstruct buffers may be slices of larger buffers, in which case it is not
sufficient to just pass through the buffer and length; this adds an
additional argument to pass b.Cstruct.off down to the mirage-solo5
stubs. Bump mirage-solo5 dependency to >= 0.5.0 accordingly.

Note that Cstruct buffers with a non-zero off are not currently used
anywhere in the network stack; this is merely future-proofing while
doing the same changes for the block stubs where they are required.