### PR TITLE
Change lang dune to 1.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.7)
+(lang dune 1.0)
 (name mirage-net-solo5)


### PR DESCRIPTION
Fix a typo : `lang dune` should be `1.0`.
As mentionned by @hannesm in #29.