### PR TITLE
use metrics to report statistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-muen"
-        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-genode"
         - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-spt"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v0.6.2 (2020-09-04)
+
+* Netif.listen does not catch Out_of_memory anymore (@hannesm, #36)
+* Each network interface is now a metrics source reporting statistics
+  (see https://github.com/mirage/metrics for further information, @hannesm, #34)
+
 ## v0.6.1 (2019-11-01)
 
 * Adapt to mirage-net 3.0.0 changes (@hannesm, #35)

--- a/mirage-net-solo5.opam
+++ b/mirage-net-solo5.opam
@@ -27,6 +27,7 @@ depends: [
   "macaddr" { >= "4.0.0"}
   "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
   "logs" {>= "0.6.0"}
+  "metrics"
   "fmt"
 ]
 synopsis: "Solo5 implementation of MirageOS network interface"

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
   (name netif)
   (public_name mirage-net-solo5)
-  (libraries cstruct macaddr logs mirage-solo5 lwt mirage-net fmt))
+  (libraries cstruct macaddr logs mirage-solo5 lwt mirage-net fmt metrics))

--- a/src/netif.ml
+++ b/src/netif.ml
@@ -29,6 +29,7 @@ type t = {
   mac: Macaddr.t;
   mtu: int;
   stats: Mirage_net.stats;
+  metrics: (string -> Metrics.field list, Mirage_net.stats -> Metrics.data) Metrics.src
 }
 
 type error = [
@@ -57,6 +58,19 @@ external solo5_net_write:
   int64 -> Cstruct.buffer -> int -> int -> solo5_result =
       "mirage_solo5_net_write_3"
 
+let net_metrics () =
+  let open Metrics in
+  let doc = "Network statistics" in
+  let data stat =
+    Data.v
+      [ uint64 "received bytes" stat.Mirage_net.rx_bytes
+      ; uint32 "received packets" stat.rx_pkts
+      ; uint64 "transmitted bytes" stat.tx_bytes
+      ; uint32 "transmitted packets" stat.tx_pkts ]
+  in
+  let tag = Tags.string "ifname" in
+  Src.v ~doc ~tags:Tags.[ tag ] ~data "net-solo5"
+
 let connect devname =
   match solo5_net_acquire devname with
     | (SOLO5_R_OK, handle, ni) -> (
@@ -66,8 +80,9 @@ let connect devname =
          Log.info (fun f -> f "Plugging into %s with mac %a mtu %d"
                       devname Macaddr.pp mac ni.solo5_mtu);
          let stats = Mirage_net.Stats.create () in
+         let metrics = net_metrics () in
          let t = {
-           id=devname; handle; active = true; mac; mtu = ni.solo5_mtu; stats
+           id=devname; handle; active = true; mac; mtu = ni.solo5_mtu; stats ; metrics
          } in
          Lwt.return t
        )
@@ -89,6 +104,7 @@ let rec read t buf =
         t.handle buf.Cstruct.buffer buf.Cstruct.off buf.Cstruct.len with
       | (SOLO5_R_OK, len)    ->
         Mirage_net.Stats.rx t.stats (Int64.of_int len);
+        Metrics.add t.metrics (fun x -> x t.id) (fun d -> d t.stats);
         let buf = Cstruct.sub buf 0 len in
         Ok buf
       | (SOLO5_R_AGAIN, _)   -> Error `Continue
@@ -146,6 +162,7 @@ let write_pure t ~size fill =
     match solo5_net_write t.handle buf.Cstruct.buffer 0 len with
     | SOLO5_R_OK      ->
       Mirage_net.Stats.tx t.stats (Int64.of_int len);
+      Metrics.add t.metrics (fun x -> x t.id) (fun d -> d t.stats);
       Ok ()
     | SOLO5_R_AGAIN   -> assert false (* Not returned by solo5_net_write() *)
     | SOLO5_R_EINVAL  -> Error `Invalid_argument


### PR DESCRIPTION
The motivation is to use the `Metrics` library for reporting interface statistics. The statistics are already gathered / accumulated via the `stats` API (I plan to deprecate that API in the soon future).

The implementation defines a `net_metrics` value, which is a Metrics source. Every read and write pushes a new data-point with increased counters of bytes/packets received/sent. The interface _name_ is annotated as a tag to each data-point.